### PR TITLE
Nakadi timeouts

### DIFF
--- a/src/main/scala/org/zalando/react/nakadi/NakadiActorPublisher.scala
+++ b/src/main/scala/org/zalando/react/nakadi/NakadiActorPublisher.scala
@@ -10,8 +10,7 @@ import org.zalando.react.nakadi.NakadiActorPublisher.CommitOffsets
 import org.zalando.react.nakadi.NakadiMessages.{Offset, StringConsumerMessage}
 
 import scala.annotation.tailrec
-import scala.concurrent.duration._
-import scala.language.postfixOps
+import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
 

--- a/src/main/scala/org/zalando/react/nakadi/NakadiActorPublisher.scala
+++ b/src/main/scala/org/zalando/react/nakadi/NakadiActorPublisher.scala
@@ -40,8 +40,6 @@ class NakadiActorPublisher(consumerAndProps: ReactiveNakadiConsumer, leaseManage
   private val client: ActorRef = consumerAndProps.nakadiClient
   private var streamSupervisor: Option[ActorRef] = None
   private val reconnectTimeout: Duration = consumerAndProps.properties.batchFlushTimeoutInSeconds * 1.5
-  context.setReceiveTimeout(reconnectTimeout)
-
   private val MaxBufferSize = 100
   private var buf = Vector.empty[StringConsumerMessage]
 
@@ -129,6 +127,7 @@ class NakadiActorPublisher(consumerAndProps: ReactiveNakadiConsumer, leaseManage
 
   def start() = {
     if (!isRunning) {
+      context.setReceiveTimeout(reconnectTimeout)
       isRunning = true
       client ! ConsumeCommand.Start
     }


### PR DESCRIPTION
Throw an exception if Nakadi doesn't send an event within the configured timeout setting, this should restart the actor and reconnect to Nakadi.